### PR TITLE
閲覧履歴修正

### DIFF
--- a/public/react-routers/src/js/components/Article.js
+++ b/public/react-routers/src/js/components/Article.js
@@ -33,22 +33,23 @@ class Article extends React.Component {
               querySnapshot.forEach((doc) => {
                 history_doc_id.push(doc.id);
               });
+              if (!history_doc_id[0]) {
+                // 閲覧履歴に今の小説がなければ、追加する
+                db.collection('histories').add({
+                  novel_doc_id: novel_id,
+                  read_at: firebase.firestore.FieldValue.serverTimestamp(),
+                  user_doc_id: user_doc_id[0],
+                });
+              } else {
+                // 閲覧履歴にあれば、閲覧の時刻をアップデート
+                return db
+                  .collection('histories')
+                  .doc(history_doc_id[0])
+                  .update({
+                    read_at: firebase.firestore.FieldValue.serverTimestamp(),
+                  });
+              }
             });
-
-          // TODO: 多分ここからうまく機能していない。ifが必ずtrueになっているっぽい？
-          if (!history_doc_id[0]) {
-            // 閲覧履歴に今の小説がなければ、追加する
-            db.collection('histories').add({
-              novel_doc_id: novel_id,
-              read_at: firebase.firestore.FieldValue.serverTimestamp(),
-              user_doc_id: user_doc_id[0],
-            });
-          } else {
-            // 閲覧履歴にあれば、閲覧の時刻をアップデート
-            return db.collection('histories').doc(history_doc_id[0]).update({
-              read_at: firebase.firestore.FieldValue.serverTimestamp(),
-            });
-          }
         });
     }
 

--- a/public/react-routers/src/js/pages/History.js
+++ b/public/react-routers/src/js/pages/History.js
@@ -24,8 +24,9 @@ export default class extends React.Component {
         });
         // user_doc_idの一つ目の人の閲覧履歴を5件だけリストアップ
         db.collection('histories')
-          .limit(5)
           .where('user_doc_id', '==', user_doc_id[0])
+          .orderBy('read_at', 'desc')
+          .limit(5)
           .get()
           .then((querySnapshot) => {
             querySnapshot.forEach((doc) => {


### PR DESCRIPTION
#58 

閲覧履歴にないときだけちゃんと追加できるようにした（今までに追加された不要なものも消せているはず）
そのために複合インデックス的なのをはってます

ついでに閲覧履歴の表示を**最新**五件にしました