### PR TITLE
検索時に10件だけ表示する

### DIFF
--- a/public/react-routers/src/css/design.css
+++ b/public/react-routers/src/css/design.css
@@ -500,6 +500,15 @@ footer {
   display: block;
 }
 
+.search-page .paging {
+  margin: 10px auto;
+  text-align: center;
+}
+
+.search-page .paging .paging-button {
+  margin: 0 5px;
+}
+
 /* ログインページ設定 */
 .form-wrapper {
   background: #fafafa;


### PR DESCRIPTION
#64

検索時の表示を10件にして、それ以上、以下はボタンで動かす。
ページ番号が1つしか表示していない（直接ページを指定できない）のは、全件取得しないとページ総数がわからないし、全件取得繰り返すとすぐ検索の制限に引っかかりそうだからです。
